### PR TITLE
Update 0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 Rport helps you to manage your remote servers without the hassle of VPNs, chained SSH connections, jump-hosts, or the use of commercial tools like TeamViewer and its clones.
 
 
-**Shipped version:** 0.7.0~ynh1
+**Shipped version:** 0.8.0~ynh1
 
 ## Screenshots
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -18,7 +18,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 Rport helps you to manage your remote servers without the hassle of VPNs, chained SSH connections, jump-hosts, or the use of commercial tools like TeamViewer and its clones.
 
 
-**Version incluse :** 0.7.0~ynh1
+**Version incluse :** 0.8.0~ynh1
 
 ## Captures d'écran
 

--- a/conf/amd64.src
+++ b/conf/amd64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/cloudradar-monitoring/rport/releases/download/0.7.0/rportd_0.7.0_Linux_x86_64.tar.gz
-SOURCE_SUM=47ca9d1092523aa33af3938bbc0a1f81c75f1fbb9394a97a98c71a263ad86a92
+SOURCE_URL=https://github.com/cloudradar-monitoring/rport/releases/download/0.8.0/rportd_0.8.0_Linux_x86_64.tar.gz
+SOURCE_SUM=e7bdf0d03c1694e459de15fcc5835c9dc6ee59fb4d202da979cbb99443e5b8bc
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=false

--- a/conf/arm64.src
+++ b/conf/arm64.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/cloudradar-monitoring/rport/releases/download/0.7.0/rportd_0.7.0_Linux_aarch64.tar.gz
-SOURCE_SUM=9ea1119c796e41b1101f9931379ad55cbce9d3a0cf47e6a0477e6728c02a8a71
+SOURCE_URL=https://github.com/cloudradar-monitoring/rport/releases/download/0.8.0/rportd_0.8.0_Linux_aarch64.tar.gz
+SOURCE_SUM=d4ec85d0188b30d6b9a6b073d120235a8d5476d049e7aa36a86c93ecd2f4d55c
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=false

--- a/conf/armhf.src
+++ b/conf/armhf.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://github.com/cloudradar-monitoring/rport/releases/download/0.7.0/rportd_0.7.0_Linux_armv7l.tar.gz
-SOURCE_SUM=a3968ed81b83ef9f9452b1048040f5aa894710e069ef551ecfa43db60101d100
+SOURCE_URL=https://github.com/cloudradar-monitoring/rport/releases/download/0.8.0/rportd_0.8.0_Linux_armv7l.tar.gz
+SOURCE_SUM=468b35c23b481ef1ef97de02071c79e2bb686c67131925d3e8ae9b604dd09b57
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=false

--- a/conf/frontend.src
+++ b/conf/frontend.src
@@ -1,5 +1,5 @@
-SOURCE_URL=https://downloads.rport.io/frontend/stable/rport-frontend-stable-0.7.0-build-1026.zip
-SOURCE_SUM=76cf75805fceb7e19a80bf170b638fa993f0c9e8e1f8d8776f7fe16504147fa4
+SOURCE_URL=https://downloads.rport.io/frontend/stable/rport-frontend-stable-0.8.0-build-1092.zip
+SOURCE_SUM=88da20241514a911f63f9ca3cf5a3631368b66eb30087cddc8a852d77c5b20ac
 SOURCE_SUM_PRG=sha256sum
 SOURCE_FORMAT=zip
 SOURCE_IN_SUBDIR=false

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
     "description": {
         "en": "Manage your remote servers"
     },
-    "version": "0.7.0~ynh1",
+    "version": "0.8.0~ynh1",
     "url": "https://rport.io/",
     "upstream": {
         "license": "MIT",


### PR DESCRIPTION
## Problem

- *Compatibility issue with clients < 0.6.4 and servers > 0.6.4 are solved. RPortd 0.8.0 is again compatible with any client version > 0.4.0.*

## Solution

- *Update version 0.8.0*

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
